### PR TITLE
#167313400 Users should be able to reset password via email

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "undoseeds": "babel-node node_modules/.bin/sequelize db:seed:undo",
     "migration": "babel-node node_modules/.bin/sequelize db:migrate",
     "undomigration": "export NODE_ENV=test && npm run undoseeds && babel-node node_modules/.bin/sequelize db:migrate:undo:all",
+    "runmigrations": "npm run undoseeds && npm run migration && npm run seeds",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "test": "export NODE_ENV=test && npm run undomigration && npm run migration && npm run seeds && nyc --reporter=html --reporter=text mocha ./test --no-timeout --exit --require @babel/register",
-    "dev": "npm run undoseeds && npm run seeds && nodemon --exec babel-node ./src/app.js"
-  
+    "dev": "nodemon --exec babel-node ./src/app.js"
   },
   "author": "Andela Simulations Programme",
   "license": "MIT",

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -31,13 +31,15 @@ class Helper {
   }
 
   /**
-   * Gnerate Token
+   * Generate Token
    * @param {string} payload
+   * @param {string} expiresInPeriod
    * @returns {string} token
    */
-  static generateToken(payload) {
+  static generateToken(payload, expiresInPeriod) {
+    const expiresInTime = expiresInPeriod || (24 * 60 * 60);
     const token = jwt.sign(payload,
-      process.env.SECRET_KEY);
+      process.env.SECRET_KEY, { expiresIn: expiresInTime });
     return token;
   }
 

--- a/src/middlewares/validators/resetpassword.validation.js
+++ b/src/middlewares/validators/resetpassword.validation.js
@@ -1,0 +1,32 @@
+import Joi from 'joi';
+import Util from '../../helpers/util';
+
+const util = new Util();
+
+export default (req, res, next) => {
+  const { password, confirmPassword } = req.body;
+
+  if (password !== confirmPassword) {
+    util.setError(400, 'Passwords provided do not match');
+    return util.send(res);
+  }
+
+  const schema = {
+    password: Joi.string().trim().regex(/^(?:(?=.*[a-z])(?:(?=.*[A-Z])(?=.*[\d\W])|(?=.*\W)(?=.*\d))|(?=.*\W)(?=.*[A-Z])(?=.*\d)).{8,}$/).required(),
+  };
+  const { error } = Joi.validate({
+    password
+  }, schema);
+
+  if (!error) return next();
+  const errorMessageFromJoi = error.details[0].message;
+
+  if (errorMessageFromJoi.includes('fails to match the required pattern')) {
+    util.setError(400, 'Password should be altleast 8 characters, Contain both uppercase and lower case and a combination of letters, numbers and symbols');
+    return util.send(res);
+  }
+  if (errorMessageFromJoi === '"password" is not allowed to be empty') {
+    util.setError(400, 'No password was specified');
+    return util.send(res);
+  }
+};

--- a/src/routes/api/user/doc.js
+++ b/src/routes/api/user/doc.js
@@ -93,4 +93,49 @@
  *     responses:
  *       200:
  *         description: User logged out successfully
+ * /users/reset:
+ *   post:
+ *     description: request for a password reset
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - in: body
+ *         name: reset password
+ *         description: password reset
+ *         schema:
+ *          type: object
+ *          required:
+ *            - email
+ *         properties:
+ *           email:
+ *              type: string
+ *     responses:
+ *       200:
+ *         description: Check your email address to reset your password
+ *       400:
+ *         description: Validation error
+ * /users/reset/:token:
+ *   post:
+ *     description: handle password reset logic
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - in: body
+ *         name: user
+ *         description: request for password reset
+ *         schema:
+ *          type: object
+ *          required:
+ *            - password
+ *            - confirmPassword
+ *         properties:
+ *           password:
+ *              type: string
+ *           confirmPassword:
+ *              type: string
+ *     responses:
+ *       200:
+ *         description: Successfully reset your password
+ *       400:
+ *         description: Validation error
  */

--- a/src/routes/api/user/user.route.js
+++ b/src/routes/api/user/user.route.js
@@ -5,6 +5,7 @@ import validateUser from '../../../middlewares/validators/signup.validation';
 import admin from '../../../middlewares/admin';
 import verifyEmail from '../../../controllers/verify-controller';
 import confirmEmaiAuth from '../../../middlewares/emailVarification.middleware';
+import resetPasswordValidation from '../../../middlewares/validators/resetpassword.validation';
 
 const router = express.Router();
 router.get('/verify', verifyEmail);
@@ -16,5 +17,9 @@ router.delete('/:id', [validateToken, confirmEmaiAuth], UserController.deleteUse
 router.put('/update/:email', [validateToken, confirmEmaiAuth], UserController.updateUser);
 router.post('/signup/admin', [validateToken, admin, confirmEmaiAuth], UserController.createAdmin);
 router.post('/signout', validateToken, UserController.signoutUser);
+
+// reset password route handlers
+router.post('/reset', UserController.requestPasswordReset);
+router.patch('/reset/:token', resetPasswordValidation, UserController.handlePasswordReset);
 
 export default router;

--- a/src/services/resetpassword.service.js
+++ b/src/services/resetpassword.service.js
@@ -1,0 +1,38 @@
+import 'dotenv/config';
+import sgMail from '@sendgrid/mail';
+
+const sendEmail = (email, username, url) => {
+  sgMail.setApiKey(process.env.SendGridApiKey);
+
+  const msg = {
+    to: `${email}`,
+    from: `${process.env.SENDER_EMAIL}`,
+    subject: 'How to reset your Author\'s Haven account password.',
+    text: 'Follow this link provided to reset your password',
+    html: `<div style="width: 90%; margin: 5rem auto; box-shadow: 0 0 10px rgba(0,0,0,.9);">
+        <div>
+            <div>
+                <div style="background-color: #2084ba; height: 3rem; width: 100%">
+                    <h2 style="text-align: center; color: white; padding-top: 10px;">Author's Heaven</h2>
+                </div>
+                <h4 style="text-align: center">Hi! ${username}</h4>
+            </div>
+            <div style=" padding: 0px 20px 20px 20px">
+                <div>
+                <p>You are recieving this because you (or someone else) requested the reset of your password for your account</p></br>
+                <p>This link is valid for only one hour</p>
+                <p>Please click on the link, or paste this into your browser to complete the process</p>
+                ${url}
+            </div>
+            <div>
+                <h3 style="text-align: center">Thank you</h3>
+            </div>
+            </div>
+        </div>
+    </div>`,
+  };
+  sgMail.send(msg);
+  return true;
+};
+
+export default sendEmail;

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -245,4 +245,97 @@ describe('Users', () => {
         });
     });
   });
+  describe('Reset password feature', () => {
+    describe('/reset endpoint', () => {
+      it('should return send email having reset password link', (done) => {
+        chai
+          .request(server)
+          .post('/api/v1/users/reset')
+          .send({
+            email: 'habineza@gmail.com'
+          })
+          .end((error, res) => {
+            expect(res.status).to.be.equal(200);
+            expect(res.body).to.have.deep.property('message', 'Check your email address to reset your password');
+            done();
+          });
+      });
+      it('should return send email having reset password link', (done) => {
+        chai
+          .request(server)
+          .post('/api/v1/users/reset')
+          .send({
+            email: 'unexistingemail@gmail.com'
+          })
+          .end((error, res) => {
+            expect(res.status).to.be.equal(400);
+            expect(res.body).to.have.deep.property('message');
+            done();
+          });
+      });
+
+      describe('/reset endpoint', () => {
+        it('should return send email having reset password link', (done) => {
+          const token = usertoken.slice(7, usertoken.length);
+          chai
+            .request(server)
+            .patch(`/api/v1/users/reset/${token}`)
+            .send({
+              password: '@234Aqwert',
+              confirmPassword: '@234Aqwert',
+            })
+            .end((error, res) => {
+              expect(res.status).to.be.equal(200);
+              expect(res.body).to.have.deep.property('message');
+              done();
+            });
+        });
+        it('should return error if no password provided', (done) => {
+          const token = usertoken.slice(7, usertoken.length);
+          chai
+            .request(server)
+            .patch(`/api/v1/users/reset/${token}`)
+            .send({
+              password: '',
+              confirmPassword: '',
+            })
+            .end((error, res) => {
+              expect(res.status).to.be.equal(400);
+              expect(res.body).to.have.deep.property('message');
+              done();
+            });
+        });
+        it('should return error if a weak password provided', (done) => {
+          const token = usertoken.slice(7, usertoken.length);
+          chai
+            .request(server)
+            .patch(`/api/v1/users/reset/${token}`)
+            .send({
+              password: 'sss',
+              confirmPassword: 'sss',
+            })
+            .end((error, res) => {
+              expect(res.status).to.be.equal(400);
+              expect(res.body).to.have.deep.property('message');
+              done();
+            });
+        });
+        it('should return error if a password do not match', (done) => {
+          const token = usertoken.slice(7, usertoken.length);
+          chai
+            .request(server)
+            .patch(`/api/v1/users/reset/${token}`)
+            .send({
+              password: 'ssssd',
+              confirmPassword: 'sss',
+            })
+            .end((error, res) => {
+              expect(res.status).to.be.equal(400);
+              expect(res.body).to.have.deep.property('message');
+              done();
+            });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- Users should be able to reset password via email
#### Description of Task to be completed?
- Password reset functionality is missing in our application. Its invaluable in instances where our users forget their login credentials
#### How should this be manually tested?
- `git checkout -b ft-user-password-reset-167313400`
- `git pull origin ft-user-password-reset-167313400`
- `npm install`
- `npm run dev`
- Using POST method, use `api/v1/users/reset` endpoint with email attribute in req.body the user must be registered
- A password reset email having a reset password link is sent to the owner of the email address used above
- Copy the link in the email body then paste in it postman.
- Using the PATCH method make sure you send the request having in the req.body `password and confirmPassword`.

#### What are the relevant pivotal tracker stories?
[#167313400](https://www.pivotaltracker.com/story/show/167313400)
#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2019-08-13 at 18 58 34" src="https://user-images.githubusercontent.com/31512000/62961103-69720880-bdfc-11e9-8b18-919bdc94d4dc.png">

