### PR TITLE
#167313412 pagination support for articles

### DIFF
--- a/src/controllers/articles.controller.js
+++ b/src/controllers/articles.controller.js
@@ -69,6 +69,7 @@ class Articles {
    * @memberof Articles
    */
   static async getAllArticles(req, res) {
+    const counter = await db.count();
     let page = parseInt(req.query.page, 10);
     if (isNaN(page) || page < 1) {
       page = 1;
@@ -81,7 +82,11 @@ class Articles {
     } else if (limit < 1) {
       limit = 1;
     }
-    const offset = (page - 1) * limit;
+    let offset = (page - 1) * limit;
+    if (offset >= counter) {
+      offset = 0;
+    }
+
     const articles = await articleService.getAllArticles(offset, limit);
     if (!articles) {
       return res.status(200).json({ status: 200, message: 'There is no article.' });
@@ -97,6 +102,7 @@ class Articles {
     return res.status(200).json({
       status: 200,
       message: 'List of all articles',
+      allArticle: counter,
       data: allArticles
     });
   }

--- a/src/controllers/articles.controller.js
+++ b/src/controllers/articles.controller.js
@@ -69,6 +69,19 @@ class Articles {
    * @memberof Articles
    */
   static async getAllArticles(req, res) {
+    let page = parseInt(req.query.page, 10);
+    if (isNaN(page) || page < 1) {
+      page = 1;
+    }
+    let limit = parseInt(req.query.limit, 10);
+    if (isNaN(limit)) {
+      limit = 10;
+    } else if (limit > 50) {
+      limit = 50;
+    } else if (limit < 1) {
+      limit = 1;
+    }
+    const offset = (page - 1) * limit;
     const articles = await articleService.getAllArticles();
     if (!articles) {
       return res.status(200).json({ status: 200, message: 'There is no article.' });

--- a/src/controllers/articles.controller.js
+++ b/src/controllers/articles.controller.js
@@ -82,7 +82,7 @@ class Articles {
       limit = 1;
     }
     const offset = (page - 1) * limit;
-    const articles = await articleService.getAllArticles();
+    const articles = await articleService.getAllArticles(offset, limit);
     if (!articles) {
       return res.status(200).json({ status: 200, message: 'There is no article.' });
     }

--- a/src/routes/api/article/article.routes.js
+++ b/src/routes/api/article/article.routes.js
@@ -9,9 +9,9 @@ import confirmEmailAuth from '../../../middlewares/emailVarification.middleware'
 const router = express.Router();
 
 
-router.post('/articles', [auth, confirmEmailAuth], imageUpload.array('images', 10), validate(schema.articleSchema), articleController.createArticles);
-router.get('/articles', [auth, confirmEmailAuth], articleController.getAllArticles);
-router.get('/articles/:slug', [auth, confirmEmailAuth], articleController.getOneArticle);
-router.delete('articles/:slug', [auth, confirmEmailAuth], articleController.deleteArticle);
-router.patch('articles/:slug', [auth, confirmEmailAuth], imageUpload.array('images', 10), articleController.UpdateArticle);
+router.post('/', [auth, confirmEmailAuth], imageUpload.array('images', 10), validate(schema.articleSchema), articleController.createArticles);
+router.get('/', articleController.getAllArticles);
+router.get('/:slug', articleController.getOneArticle);
+router.delete('/:slug', [auth, confirmEmailAuth], articleController.deleteArticle);
+router.patch('/:slug', [auth, confirmEmailAuth], imageUpload.array('images', 10), articleController.UpdateArticle);
 export default router;

--- a/src/routes/api/index.route.js
+++ b/src/routes/api/index.route.js
@@ -19,7 +19,7 @@ router.use(oauth);
 router.use('/profile', profile);
 router.use('/likes', likes);
 router.use('/users', user);
-router.use('/', article);
+router.use('/articles', article);
 router.use('/rate', rate);
 router.use('/api-docs', swaggerui.serve, swaggerui.setup(swaggerSpecification));
 

--- a/src/services/article.service.js
+++ b/src/services/article.service.js
@@ -28,12 +28,20 @@ class articleService {
    *
    *
    * @static
+   *  @param {*} offset
+   *  @param {*} limit
    * @returns {object} data
    * @memberof articleService
    */
-  static async getAllArticles() {
+  static async getAllArticles(offset, limit) {
     try {
-      return await db.findAll();
+      return await db.findAll({
+        order: [
+          ['updatedAt', 'DESC']
+        ],
+        offset,
+        limit,
+      });
     } catch (error) {
       throw error;
     }

--- a/src/services/article.service.js
+++ b/src/services/article.service.js
@@ -37,7 +37,7 @@ class articleService {
     try {
       return await db.findAll({
         order: [
-          ['updatedAt', 'DESC']
+          ['createdAt', 'DESC']
         ],
         offset,
         limit,

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -1,0 +1,29 @@
+import { chai, server, expect } from './test-setup';
+
+
+describe('/Article pagination', () => {
+  it('Should successfully retrieve  latest published ten articles', (done) => {
+    chai
+      .request(server)
+      .get('/api/v1/articles')
+      .end((error, res) => {
+        expect(res).have.status(200);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.keys('message', 'status', 'data', 'allArticle');
+        expect(res.body.message).to.deep.equal('List of all articles');
+        done();
+      });
+  });
+  it('Should successfully retrieve articles from the 2nd to the up to atmost 4th if up to atmost 4 if exist if not is going to fech from 1st one to 2nd article ', (done) => {
+    chai
+      .request(server)
+      .get('/api/v1/articles')
+      .end((error, res) => {
+        expect(res).have.status(200);
+        expect(res).to.be.an('object');
+        expect(res.body).to.have.keys('message', 'status', 'data', 'allArticle');
+        expect(res.body.message).to.deep.equal('List of all articles');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
-pagination support for an article

#### Description of Task to be completed?

- when a user request articles can specify the article limit and page  in a request parameters 

- by default, if it is not specified is returning latest published ten articles

- the limit of articles for one page can't go beyond 50 articles 
-the results bring the total number of articles which is in a database which will help for UI setting up the number of pages user can  next too
-`if the offset is beyond or equals the whole total number  of articles  according to queries you send the offset is going to be set to zero`

#### How should this be manually tested?

- checkout to this branch and send a GET request to `/articles?page=2&&limit=3`

- is is in the description above those `req queries ` is not a must 

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?
[#167313412](https://www.pivotaltracker.com/story/show/167313412)

#### Screenshots (if appropriate)
<img width="1036" alt="Screen Shot 2019-08-21 at 19 22 45" src="https://user-images.githubusercontent.com/38810299/63457019-6dcba080-c450-11e9-82ee-24327f734c60.png">
<img width="1036" alt="Screen Shot 2019-08-21 at 19 16 32" src="https://user-images.githubusercontent.com/38810299/63457034-73c18180-c450-11e9-837d-c086a848e24f.png">


#### Questions:
