### PR TITLE
#167313416 Users should be able to share articles across different channels

### DIFF
--- a/src/controllers/articles.controller.js
+++ b/src/controllers/articles.controller.js
@@ -9,6 +9,7 @@ import articleService from '../services/article.service';
 import Helper from '../helpers/helper';
 import NotificationServices from '../services/notification.service';
 import cloudinaryHelper from '../helpers/cloudinaryHelper';
+import OpenUrlHelper from '../helpers/share.article.helper';
 
 const { notifyViaEmailAndPush } = NotificationServices;
 
@@ -207,11 +208,11 @@ class Articles {
    * @memberof Articles
    */
   static async shareArticle(req, res) {
-    const articleSlug = await db.findOne({
+    const article = await db.findOne({
       where: { slug: req.params.slug }
     });
 
-    if (!articleSlug) {
+    if (!article) {
       return res.status(404).json({
         status: 404,
         message: 'Article is not found.'
@@ -221,26 +222,23 @@ class Articles {
     const url = `${location}/articles/${req.params.slug}`;
     switch (req.params.channel) {
       case 'facebook':
-        if (process.env.NODE_ENV !== 'test') open(`https:www.facebook.com/sharer/sharer.php?u=${url}`);
-        res.status(200).json({
+        await OpenUrlHelper.openUrl(`https:www.facebook.com/sharer/sharer.php?u=${url}`);
+        return res.status(200).json({
           status: 200,
           message: `Article shared to ${req.params.channel}`,
         });
-        break;
       case 'twitter':
-        if (process.env.NODE_ENV !== 'test') { open(`https://twitter.com/intent/tweet?url=${url}`); }
-        res.status(200).json({
+        await OpenUrlHelper.openUrl(`https://twitter.com/intent/tweet?url=${url}`);
+        return res.status(200).json({
           status: 200,
           message: `Article shared to ${req.params.channel}`,
         });
-        break;
       case 'mail':
-        if (process.env.NODE_ENV !== 'test') open(`mailto:?subject=${slug}&body=${url}`);
-        res.status(200).json({
+        await OpenUrlHelper.openUrl(`mailto:?subject=${article.title}&body=${url}`);
+        return res.status(200).json({
           status: 200,
           message: `Article shared to ${req.params.channel}`,
         });
-        break;
       default:
         break;
     }

--- a/src/controllers/articles.controller.js
+++ b/src/controllers/articles.controller.js
@@ -1,3 +1,4 @@
+import open from 'open';
 import 'dotenv/config';
 import slug from 'slug';
 import _ from 'lodash';
@@ -194,6 +195,55 @@ class Articles {
       status: 200,
       updatedArticle
     });
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {*} req
+   * @param {*} res
+   * @returns {Object} share article over email and social media channelds
+   * @memberof Articles
+   */
+  static async shareArticle(req, res) {
+    const articleSlug = await db.findOne({
+      where: { slug: req.params.slug }
+    });
+
+    if (!articleSlug) {
+      return res.status(404).json({
+        status: 404,
+        message: 'Article is not found.'
+      });
+    }
+    const location = `${process.env.BACKEND_URL}/api/${process.env.API_VERSION}`;
+    const url = `${location}/articles/${req.params.slug}`;
+    switch (req.params.channel) {
+      case 'facebook':
+        if (process.env.NODE_ENV !== 'test') open(`https:www.facebook.com/sharer/sharer.php?u=${url}`);
+        res.status(200).json({
+          status: 200,
+          message: `Article shared to ${req.params.channel}`,
+        });
+        break;
+      case 'twitter':
+        if (process.env.NODE_ENV !== 'test') { open(`https://twitter.com/intent/tweet?url=${url}`); }
+        res.status(200).json({
+          status: 200,
+          message: `Article shared to ${req.params.channel}`,
+        });
+        break;
+      case 'mail':
+        if (process.env.NODE_ENV !== 'test') open(`mailto:?subject=${slug}&body=${url}`);
+        res.status(200).json({
+          status: 200,
+          message: `Article shared to ${req.params.channel}`,
+        });
+        break;
+      default:
+        break;
+    }
   }
 }
 

--- a/src/controllers/articles.controller.js
+++ b/src/controllers/articles.controller.js
@@ -1,4 +1,3 @@
-import open from 'open';
 import 'dotenv/config';
 import slug from 'slug';
 import _ from 'lodash';
@@ -10,8 +9,11 @@ import Helper from '../helpers/helper';
 import NotificationServices from '../services/notification.service';
 import cloudinaryHelper from '../helpers/cloudinaryHelper';
 import OpenUrlHelper from '../helpers/share.article.helper';
+import Util from '../helpers/util';
+
 
 const { notifyViaEmailAndPush } = NotificationServices;
+const util = new Util();
 
 const db = models.Article;
 /**
@@ -213,32 +215,24 @@ class Articles {
     });
 
     if (!article) {
-      return res.status(404).json({
-        status: 404,
-        message: 'Article is not found.'
-      });
+      util.setError(404, 'Article is not found.');
+      return util.send(res);
     }
     const location = `${process.env.BACKEND_URL}/api/${process.env.API_VERSION}`;
     const url = `${location}/articles/${req.params.slug}`;
     switch (req.params.channel) {
       case 'facebook':
         await OpenUrlHelper.openUrl(`https:www.facebook.com/sharer/sharer.php?u=${url}`);
-        return res.status(200).json({
-          status: 200,
-          message: `Article shared to ${req.params.channel}`,
-        });
+        util.setError(200, `Article shared to ${req.params.channel}`);
+        return util.send(res);
       case 'twitter':
         await OpenUrlHelper.openUrl(`https://twitter.com/intent/tweet?url=${url}`);
-        return res.status(200).json({
-          status: 200,
-          message: `Article shared to ${req.params.channel}`,
-        });
+        util.setError(200, `Article shared to ${req.params.channel}`);
+        return util.send(res);
       case 'mail':
         await OpenUrlHelper.openUrl(`mailto:?subject=${article.title}&body=${url}`);
-        return res.status(200).json({
-          status: 200,
-          message: `Article shared to ${req.params.channel}`,
-        });
+        util.setError(200, `Article shared to ${req.params.channel}`);
+        return util.send(res);
       default:
         break;
     }

--- a/src/helpers/share.article.helper.js
+++ b/src/helpers/share.article.helper.js
@@ -1,5 +1,7 @@
 import open from 'open';
 
 const openUrl = url => open(url);
+
 const OpenUrlHelper = { openUrl };
+
 export default OpenUrlHelper;

--- a/src/helpers/share.article.helper.js
+++ b/src/helpers/share.article.helper.js
@@ -1,7 +1,5 @@
 import open from 'open';
 
 const openUrl = url => open(url);
-
 const OpenUrlHelper = { openUrl };
-
 export default OpenUrlHelper;

--- a/src/routes/api/article/article.routes.js
+++ b/src/routes/api/article/article.routes.js
@@ -27,6 +27,7 @@ router.get('/', checkQuery, articleController.getAllArticles);
 router.get('/:slug', articleController.getOneArticle);
 router.delete('/:slug', [auth, confirmEmailAuth], articleController.deleteArticle);
 router.patch('/:slug', [auth, confirmEmailAuth], imageUpload.array('images', 10), articleController.UpdateArticle);
+router.post('/:slug/share/:channel', [auth, confirmEmailAuth], articleController.shareArticle);
 
 
 // Highlight

--- a/src/routes/api/article/doc.yml
+++ b/src/routes/api/article/doc.yml
@@ -127,6 +127,30 @@
         $ref: "#/responses/BadRequest"
       404:
         $ref: "#/responses/Notfound"
+/articles/{slug}/share/{channel}:
+  post:
+    description: >
+      Share an article on mail and social media channels
+    parameters:
+      - name: slug
+        in: path
+        description: Slug for article
+        type: string
+        required: true
+      - name: channel
+        in: path
+        description: Channel to share to
+        type: string
+        required: true
+      - name: x-access-token
+        in: header
+        schema:
+          type: string
+        required:
+          - authorization
+    responses:
+      200:
+        description: Article successfully shared
 /articles:
   post:
     summary: Create an article
@@ -436,8 +460,6 @@ definitions:
               description: Tag with name has been removed
       400:
         $ref: "#/responses/BadRequest"
-      404:
-        $ref: "#/responses/Notfound"
 /articles/{slug}/highlight:
   post:
     produces:
@@ -532,8 +554,6 @@ definitions:
         description: you are ready to share
       404:
         description: Sorry, you can not share
-     
-
-     
-
-     
+          $ref: '#/responses/Notfound'
+ 
+        

--- a/src/routes/api/article/doc.yml
+++ b/src/routes/api/article/doc.yml
@@ -151,6 +151,7 @@
     responses:
       200:
         description: Article successfully shared
+        $ref: "#/responses/Notfound"
 /articles:
   post:
     summary: Create an article

--- a/src/routes/api/article/doc.yml
+++ b/src/routes/api/article/doc.yml
@@ -555,6 +555,6 @@ definitions:
         description: you are ready to share
       404:
         description: Sorry, you can not share
-          $ref: '#/responses/Notfound'
+        $ref: '#/responses/Notfound'
  
         

--- a/src/services/notification.service.js
+++ b/src/services/notification.service.js
@@ -50,7 +50,7 @@ class NotificationServices {
         .filter(eachUser => eachUser.inAppNotification === true);
       const message = `${followedUser.username} just published an article`;
       const location = `${process.env.BACKEND_URL}/api/${process.env.API_VERSION}`;
-      const url = `${location}/api/v1/articles/${slug}`;
+      const url = `${location}/articles/${slug}`;
 
 
       if (myFollowersWithEmailSub.length !== 0) {
@@ -101,7 +101,7 @@ class NotificationServices {
       if (usersWhoFavoritedWithEmailSub.length !== 0) {
         const emailAddresses = usersWhoFavoritedWithEmailSub.map(each => each.email);
         const location = `${process.env.BACKEND_URL}/api/${process.env.API_VERSION}`;
-        const url = `${location}/api/v1/articles/${slug}`;
+        const url = `${location}/articles/${slug}`;
         const emailTemplate = newCommentOnFavoritedArticlesTemplate(req.auth.username, url);
         await sendEmail(emailAddresses, 'Hi there', emailTemplate);
       }

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -28,7 +28,6 @@ describe('search article query builder', () => {
       .set('Content-Type', 'application/json')
       .set('Authorization', usertoken)
       .end((err, res) => {
-        if (err) done(err);
         expect(res.status).to.be.deep.equal(200);
         expect(res.body).to.have.deep.property('message', 'List of all articles');
         done();
@@ -41,7 +40,6 @@ describe('search article query builder', () => {
       .set('Content-Type', 'application/json')
       .set('Authorization', usertoken)
       .end((err, res) => {
-        if (err) done(err);
         expect(res.status).to.be.deep.equal(400);
         expect(res.body).to.have.deep.property('error');
         done();

--- a/test/share.article.test.js
+++ b/test/share.article.test.js
@@ -1,0 +1,56 @@
+import sinon from 'sinon';
+import { expect } from './test-setup';
+import Article from '../src/controllers/articles.controller';
+import OpenUrlHelper from '../src/helpers/share.article.helper';
+
+describe('test for sharing an article', () => {
+  it('test for sharing an article via facebook', async () => {
+    const req = {
+      params: { slug: 'fakeslug', channel: 'facebook' },
+      auth: {
+        email: 'user@gmail.com'
+      }
+    };
+    const res = {
+      status() { },
+      send() { },
+      json() { }
+    };
+    sinon.stub(res, 'status').returnsThis();
+    sinon.stub(OpenUrlHelper, 'openUrl').returns(true);
+    await Article.shareArticle(req, res);
+    expect(res.status).to.have.been.calledWith(200);
+  });
+  it('test for sharing an article via twitter', async () => {
+    const req = {
+      params: { slug: 'fakeslug', channel: 'twitter' },
+      auth: {
+        email: 'user@gmail.com'
+      }
+    };
+    const res = {
+      status() { },
+      send() { },
+      json() { }
+    };
+    sinon.stub(res, 'status').returnsThis();
+    await Article.shareArticle(req, res);
+    expect(res.status).to.have.been.calledWith(200);
+  });
+  it('test for sharing an article via mail', async () => {
+    const req = {
+      params: { slug: 'fakeslug', channel: 'twitter' },
+      auth: {
+        email: 'user@gmail.com'
+      }
+    };
+    const res = {
+      status() { },
+      send() { },
+      json() { }
+    };
+    sinon.stub(res, 'status').returnsThis();
+    await Article.shareArticle(req, res);
+    expect(res.status).to.have.been.calledWith(200);
+  });
+});

--- a/test/share.article.test.js
+++ b/test/share.article.test.js
@@ -17,7 +17,6 @@ describe('test for sharing an article', () => {
       json() { }
     };
     sinon.stub(res, 'status').returnsThis();
-    sinon.stub(OpenUrlHelper, 'openUrl').returns(true);
     await Article.shareArticle(req, res);
     expect(res.status).to.have.been.calledWith(200);
   });


### PR DESCRIPTION
#### What does this PR do?

-  It adds functionality for sharing an article over mail and social media channels

#### Description of Task to be completed?

-  As an authenticated user, I should be able to share articles; both mine and others via email and social media platforms.

#### How should this be manually tested?

- clone the repo and then run **npm run dev**
- In your postman, execute this route **http://localhost:PORT/api/v1/articles/{slug}/share/{channel}**.  Change PORT, slug and channel accordingly. Channels can be facebook, twitter or mail.

#### What are the relevant pivotal tracker stories?

- [#167313416](https://www.pivotaltracker.com/story/show/167313416)

#### Screenshots (if appropriate)
<img width="874" alt="Screen Shot 2019-08-28 at 16 47 58" src="https://user-images.githubusercontent.com/49583916/63869844-1a5dd300-c9b9-11e9-8359-6625adcef17a.png">
<img width="1298" alt="Screen Shot 2019-08-28 at 16 48 55" src="https://user-images.githubusercontent.com/49583916/63869866-25186800-c9b9-11e9-87ca-3b70134bdb60.png">
<img width="875" alt="Screen Shot 2019-08-28 at 16 50 24" src="https://user-images.githubusercontent.com/49583916/63869940-4711ea80-c9b9-11e9-9168-368f504ceffc.png">
<img width="1342" alt="Screen Shot 2019-08-28 at 16 50 10" src="https://user-images.githubusercontent.com/49583916/63869961-52651600-c9b9-11e9-8c11-34eff1a724ab.png">

