### PR TITLE
addd express social login

### DIFF
--- a/src/controllers/social.js
+++ b/src/controllers/social.js
@@ -1,7 +1,5 @@
-/* eslint-disable require-jsdoc */
 import User from '../services/user.service';
 import Helper from '../helpers/helper';
-import verifyUser from '../helpers/verification-email';
 
 let data;
 
@@ -21,78 +19,43 @@ class Social {
    * @memberof Social
    */
   static async login(req, res) {
+    let user;
+    let message;
     data = req.user;
     const firstname = data.name ? data.name.givenName : data.displayName.split(' ')[0];
-    const lastname = data.name ? data.name.middleName : data.displayName.split(' ')[1];
+    const lastname = data.name ? data.name.middleName || data.name.familyName : data.displayName.split(' ')[1];
     const email = data.emails ? data.emails[0].value : '';
     const username = `${firstname}.${lastname}`;
     // check if user is in db
     const registeredUser = await User.findOne(email, username);
-    // format response message for case of twitter user without email add and others with
-    const message = data.emails ? `account with name ${firstname} ${lastname} does not exist, create?`
-      : `account with name ${firstname} ${lastname} does not exist, to register send email in response`;
-    // if yes user exists, generate token
     if (registeredUser) {
-      const payload = {
-        email,
-        role: registeredUser.role,
-        verified: registeredUser.verified
+      user = registeredUser;
+      message = 'Logged in successfully';
+    } else {
+      const password = Helper.hashPassword('password');
+      const newUser = {
+        firstname, lastname, email, username, password
       };
-      const token = Helper.generateToken(payload);
-      return res.status(200).json({
-        status: 200,
-        message: 'Logged in successfully',
-        data: {
-          firstname, lastname, username, email
-        },
-        token
-      });
+      user = await User.addUser(newUser);
+      message = 'login successful, account created with password password,please chane password on next login';
     }
-    res.status(200).json({ message });
-  }
-
-  /**
-    *
-    *
-    * @static
-    * @param {*} req
-    * @param {*} res
-    * @returns {Object} returns new user
-    * @memberof Social
-    */
-  static async signup(req, res) {
-    const firstname = data.name ? data.name.givenName : data.displayName.split(' ')[0];
-    const lastname = data.name ? data.name.middleName || data.name.familyName : data.displayName.split(' ')[1];
-    const email = data.emails ? data.emails[0].value : req.body.email || req.query.email;
-    const username = `${firstname}.${lastname}`;
-    const hasspassword = Helper.hashPassword('password');
-    const dbSchema = {
-      firstname, lastname, email, username, password: hasspassword
-    };
-    const createdUser = await User.addUser(dbSchema);
     const payload = {
-      email: createdUser.email,
-      role: createdUser.role,
-      verified: createdUser.verified
+      id: user.id,
+      email,
+      role: user.role,
+      verified: user.verified
     };
     const token = Helper.generateToken(payload);
-    const verifyUrl = `${process.env.BACKEND_URL}/api/${
-      process.env.API_VERSION
-    }/users/verify?token=${token}`;
-    verifyUser(payload.email, createdUser.username, verifyUrl);
-    return res.status(201).json({
-      status: 201,
-      message: 'Your account has been successfully created. An email has been sent to you with detailed instructions on how to activate it. Your default password is password, Please change on activatio',
+    return res.status(200).json({
+      status: 200,
+      message,
       data: {
-        firstname: createdUser.firstname,
-        lastname: createdUser.lastname,
-        email: createdUser.email,
-        username: createdUser.username,
-        role: createdUser.role,
+        firstname, lastname, username, email
       },
-      token,
+      token
     });
   }
 }
 
 export default Social;
+

--- a/src/routes/api/oauth/oauth.routes.js
+++ b/src/routes/api/oauth/oauth.routes.js
@@ -1,3 +1,4 @@
+
 import express from 'express';
 import Social from '../../../controllers/social';
 import passport from '../../../middlewares/passport';
@@ -7,9 +8,6 @@ const router = express.Router();
 
 // test route
 router.get('/auth/fake', fakeAuth, Social.login);
-
-// social signup consent route
-router.get('/signup/social', Social.signup);
 
 router.get('/login/facebook', passport.authenticate('facebook', { scope: ['email'] }));
 router.get('/login/facebook/callback', passport.authenticate('facebook', { session: false }), Social.login);

--- a/test/test-mock-social.js
+++ b/test/test-mock-social.js
@@ -1,3 +1,4 @@
+
 import { server, expect, chai } from './test-setup';
 
 describe('Social login tests', () => {
@@ -57,34 +58,10 @@ describe('Social login tests', () => {
         .end((err, res) => {
           if (err) { done(err); }
           expect(res.status).to.be.equal(200);
-          expect(res.body.message).to.contain('does not exist');
+          expect(res.body.message).to.contain('account created');
           done();
         });
     });
-    it('should include request for email in response to new twitter user', (done) => {
-      chai.request(server)
-        .get('/login/twitter')
-        .end((err, res) => {
-          if (err) { done(err); }
-          expect(res.status).to.be.equal(200);
-          expect(res.body.message).to.contain('send email');
-          done();
-        });
-    });
-
-    // it('should register consenting new social user', (done) => {
-    //   chai.request(server)
-    //     .get('/login/google')
-    //     .end(() => {
-    //       chai.request(server)
-    //         .get('/signup/social')
-    //         .end((error, resp) => {
-    //           expect(resp.status).to.be.equal(201);
-    //           expect(resp.body.message).to.contain('Your account has been successfully created');
-    //           done();
-    //         });
-    //     });
-    // });
   });
 });
 


### PR DESCRIPTION
#### What does this PR do?

  Remove extra dialogue in registering social user during login request

#### Description of Task to be completed?

  Expressly login social user and if not registered, register with AH without further dialogue

#### How should this be manually tested?

  send a get request to:
    - http://codepirates-ah-backend.herokuapp.com/login/google
    - http://codepirates-ah-backend.herokuapp.com/login/facebook
    - http://codepirates-ah-backend.herokuapp.com/login/twitter
   for login in with the respective services

#### Any background context you want to provide?

  Initially, a user not registered on AH would be required to consent registration, verify email, etc on a login request. This seeks to improve the user's experience by cutting out unnecessary delays and automatically registering the user on login

#### What are the relevant pivotal tracker stories?
  
 [finishes #168216530]
#### Screenshots (if appropriate)

#### Questions:
