### PR TITLE
featuture api (enable social signup): Signup social user and return u…

### DIFF
--- a/src/helpers/passwordgen.js
+++ b/src/helpers/passwordgen.js
@@ -1,0 +1,10 @@
+const randPass = () => {
+  let password = '';
+  const pattern = /[a-z].*[0-9].*/;
+  while (!pattern.test(password)) {
+    password = (Math.random() + 1).toString(36).substring(4);
+  }
+  return password;
+};
+
+export default randPass;

--- a/src/services/db.service.js
+++ b/src/services/db.service.js
@@ -1,17 +1,17 @@
 /* eslint-disable require-jsdoc */
 import models from '../models';
 
-const { Stats, Article } = models;
-const Models = { Stats, Article };
+// const { Stats, Article, user } = models;
+// const Models = { Stats, Article, user };
 const conditon = where => ({ where });
 
 class StatsService {
   static async createStat(where, model) {
-    return Models[model].create(where);
+    return models[model].create(where);
   }
 
   static async getStat(where, model) {
-    return Models[model].findAll(conditon(where));
+    return models[model].findAll(conditon(where));
   }
 }
 

--- a/test/test-mock-social.js
+++ b/test/test-mock-social.js
@@ -45,20 +45,30 @@ describe('Social login tests', () => {
     });
   });
 
-  describe('New social be registered if consents', () => {
+  describe('Test social signup', () => {
     before((done) => {
       process.env.facebook = 'facebook_new';
       process.env.google = 'google_new';
       process.env.twitter = 'twitter_new';
       done();
     });
-    it('should notify of none existent of account', (done) => {
+    it('should notify register new social user', (done) => {
       chai.request(server)
         .get('/login/facebook')
         .end((err, res) => {
           if (err) { done(err); }
-          expect(res.status).to.be.equal(200);
-          expect(res.body.message).to.contain('account created');
+          expect(res.status).to.be.equal(201);
+          expect(res.body.message).to.contain('Account created');
+          done();
+        });
+    });
+    it('should remind of email update if using twitter', (done) => {
+      chai.request(server)
+        .get('/login/twitter')
+        .end((err, res) => {
+          if (err) { done(err); }
+          expect(res.status).to.be.equal(201);
+          expect(res.body.message).to.contain('and update your email');
           done();
         });
     });


### PR DESCRIPTION
…nique random password [finishes #167313352]

#### What does this PR do?
  Enhance social signup feature

#### Description of Task to be completed?
  - Expressly signup new social user to author's haven without email verification
  - Generate 8-character unique, random starter password for new social user
  - Prompt for change of password
  - Prompt for email update in case of twitter user

#### How should this be manually tested?
  - Clone this repo using _git clone https://github.com/andela/codepirates-ah-backend.git_ in your terminal
  - Run npm install to install project dependencies
  - cd to the folder containing your clone
  - Paste _git checkout ft-api-enable-social-signup-168893366_ in your terminal
  - Create your Postgres database with the database name in your .env file
  - Run _npm run dev_ in your terminal
  - In your browser's address bar, past _localhost:3000/api/v1/login/google_ to signup with google
    - After completing all dialogue sessions, you should see a response indicating your account has been created and a password generated for traditional login
  - Enter the same address again in your browser
    - You should now see a successful login response
  Replace google with twitter for twitter signup
  - The facebook app is live and does not transact with requests from localhost
  
#### Any background context you want to provide?
  - Social login existed but
    - Did not generate a password for the new user
    - Did not prompt the new twitter registered user to update their email
    - Had some security loopholes due to the lack of an email in the twitter response

#### What are the relevant pivotal tracker stories?
  [Finishes #168893366](https://www.pivotaltracker.com/story/show/168893366)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/36167006/66099036-64803880-e5a5-11e9-95af-47a9107d28d2.png)


#### Questions:
