### PR TITLE
#169311398 Refactor articles controller to get readtime for articles

### DIFF
--- a/test/test.articles.js
+++ b/test/test.articles.js
@@ -98,4 +98,14 @@ describe('Articles', () => {
         done();
       });
   });
+  it('should return resource not found message if endpoint does not exist', (done) => {
+    chai
+      .request(server)
+      .get('/api/v1/articles/user/articl')
+      .end((error, res) => {
+        expect(res.status).to.be.equal(404);
+        expect(res.body).to.have.deep.property('error', 'Resource not found');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
-It gets all articles for a specific user
#### Description of Task to be completed?
-logged in user should be able to get all the articles he published with the time it takes to read the articles and the time articles were created 
#### How should this be manually tested?
- Download or clone the tutorial project code from [here](https://github.com/andela/codepirates-ah-backend), in your terminal then git checkout ` bug-fix-get-specif-user-articles-return-readtime-169311398`, install all required NPM packages by running NPM install from the command line in the project root folder (where the package.json is located).

- Start the API by running NPM start from the command line in the project root folder, you should see the message Server listening on port 8000. You can test the API directly using an application such as Postman or you can test it with one of the single pages in the browser.
- to test authentication and authorization, add this to the header
Key: :x-access-token,value:JWT TOKEN
#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/169311398

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/16412410/67372171-c36e1780-f57d-11e9-8f17-134c2dfaa09f.png)


#### Questions: