### PR TITLE
share front, insteat of back end link

### DIFF
--- a/src/controllers/articles.controller.js
+++ b/src/controllers/articles.controller.js
@@ -120,8 +120,8 @@ class Articles {
         try {
           const userDetails = await Userservice.getOneUser(article.authorId);
           const {
-            username, firstname, lastname, image
-          } = userDetails;
+ username, firstname, lastname, image 
+} = userDetails;
           const user = {
             username,
             firstname,
@@ -264,8 +264,8 @@ class Articles {
     ]);
     const userDetails = await Userservice.getOneUser(article.authorId);
     const {
-      username, firstname, lastname, image
-    } = userDetails;
+ username, firstname, lastname, image 
+} = userDetails;
     const user = {
       username,
       firstname,
@@ -373,8 +373,8 @@ class Articles {
       return util.send(res);
     }
     const {
-      title, body, description, images
-    } = req.body;
+ title, body, description, images 
+} = req.body;
     const updatedArticle = await articleService.updateArticle(req.params.slug, {
       title,
       body,
@@ -404,8 +404,7 @@ class Articles {
       util.setError(404, 'Article is not found.');
       return util.send(res);
     }
-    const location = `${process.env.BACKEND_URL}/api/${process.env.API_VERSION}`;
-    const url = `${location}/articles/${req.params.slug}`;
+    const { url } = req.body;
     switch (req.params.channel) {
       case 'facebook':
         await OpenUrlHelper.openUrl(


### PR DESCRIPTION
#### What does this PR do?

  Share the front end link to an article as opposed to sharing the back end link

#### Description of Task to be completed?

  - Pass the link to share in the body of the share request
 
#### How should this be manually tested?

  - Run this backend
  - On postman, make a post request to http://localhost:<*your port*>/api/v1/articles/<*valid article slug*>/share/<[mail, facebook or twitter>
  - Copy any webpage URL and supply it as the url property value in the request body
  - Ensure you have a valid token
  - Expect a browser window to open for interactive completion of the sharing
  - After completing the sharing dialogue, open whichever forum you shared to and click on the received link
  - You should see exactly the same page you shared

#### Any background context you want to provide?

The previous implementation shared the backend link to the article that returned the raw resource from the database, not readable, especially images

#### What are the relevant pivotal tracker stories?

[Fixes #169619406](https://www.pivotaltracker.com/story/show/169619406)

#### Screenshots (if appropriate)

#### Questions:
