### PR TITLE
#169672715: Allow unlogged in user to view likes of a comment

### DIFF
--- a/src/controllers/comments.controller.js
+++ b/src/controllers/comments.controller.js
@@ -35,8 +35,12 @@ class Comments {
     const getArticle = await database.findOne({
       where: { slug: req.params.slug }
     });
-    if (!getUser) return res.status(404).send({ message: `User with id ${req.auth.id} not found` });
-    if (!getArticle) return res.status(404).send({ message: `Article with slug ${req.params.slug}  not found` });
+    if (!getUser) {return res
+        .status(404)
+        .send({ message: `User with id ${req.auth.id} not found` });}
+    if (!getArticle) {return res
+        .status(404)
+        .send({ message: `Article with slug ${req.params.slug}  not found` });}
     try {
       const comment = {
         articleSlug: getArticle.slug,
@@ -46,7 +50,11 @@ class Comments {
       };
       const createdComment = await commentsService.addComment(comment);
       await notifyUsersWhoFavorited(req, res, getArticle.id, req.params.slug);
-      await util.setSuccess(201, 'Comment successfully created', createdComment);
+      await util.setSuccess(
+        201,
+        'Comment successfully created',
+        createdComment
+      );
       return util.send(res);
     } catch (error) {
       return res.send({
@@ -81,7 +89,10 @@ class Comments {
     try {
       const CommentTODelete = await commentsService.deleteComment(id);
       if (CommentTODelete) {
-        await util.setSuccess(200, `Comment with id ${id} is successfully deleted`);
+        await util.setSuccess(
+          200,
+          `Comment with id ${id} is successfully deleted`
+        );
         return util.send(res);
       }
 
@@ -113,7 +124,10 @@ class Comments {
     }
     const readerId = req.auth.id;
     const item = 'comment';
-    await StatsService.createStat({ readerId, item, slug: 'all comments' }, 'Stats');
+    await StatsService.createStat(
+      { readerId, item, slug: 'all comments' },
+      'Stats'
+    );
     await util.setSuccess(200, 'All comments successfully retrieved', comments);
     return util.send(res);
   }
@@ -169,7 +183,11 @@ class Comments {
         }
       })
     );
-    await util.setSuccess(200, 'All comments successfully retrieved', allComments);
+    await util.setSuccess(
+      200,
+      'All comments successfully retrieved',
+      allComments
+    );
     return util.send(res);
   }
 
@@ -185,14 +203,19 @@ class Comments {
    */
   static async deleteCommentOfAnArticle(req, res) {
     const userId = req.auth.id;
-    const getComment = await CommentsDb.findOne({ where: { id: req.params.id } });
+    const getComment = await CommentsDb.findOne({
+      where: { id: req.params.id }
+    });
     if (!getComment) {
       await util.setError(404, 'That article comment does not exit');
       return util.send(res);
     }
     const commentedUser = getComment.dataValues.userId;
     if (userId !== commentedUser) {
-      await util.setError(403, 'Sorry, you are not allowed to delete this comment');
+      await util.setError(
+        403,
+        'Sorry, you are not allowed to delete this comment'
+      );
       return util.send(res);
     }
     await commentsService.deleteComment(req.params.id);
@@ -211,14 +234,19 @@ class Comments {
    */
   static async updateParticularComment(req, res) {
     const userId = req.auth.id;
-    const getComment = await CommentsDb.findOne({ where: { id: req.params.id } });
+    const getComment = await CommentsDb.findOne({
+      where: { id: req.params.id }
+    });
     if (!getComment) {
       await util.setError(404, 'That article comment does not exit');
       return util.send(res);
     }
     const commentedUser = getComment.dataValues.userId;
     if (userId !== commentedUser) {
-      await util.setError(403, 'Sorry, you are not allowed to update this comment');
+      await util.setError(
+        403,
+        'Sorry, you are not allowed to update this comment'
+      );
       return util.send(res);
     }
     const { body } = req.body;
@@ -241,7 +269,9 @@ class Comments {
    * @memberof UserController
    */
   static async updateComment(req, res) {
-    const getComment = await CommentsDb.findOne({ where: { id: req.params.id } });
+    const getComment = await CommentsDb.findOne({
+      where: { id: req.params.id }
+    });
     const gottenComent = getComment && getComment.get().id;
     const { id } = req.params;
 
@@ -343,7 +373,6 @@ class Comments {
    */
   static async getLikesComments(req, res) {
     const { id } = req.params;
-    const { username } = req.auth;
     const comment = await commentsService.findOne(id);
 
     if (!comment) {
@@ -352,14 +381,10 @@ class Comments {
     }
     const { likesCount, likeInfo } = comment;
 
-    const userHasLikedBefore = likeInfo.search(username);
-
-    if (userHasLikedBefore === -1) {
-      util.setSuccess(200, 'Likes successfully retrieved', { data: { likesCount, likeInfo } });
-      return util.send(res);
-    }
-    const formattedLikeInfo = Helper.formatLikeInfo(likeInfo.replace(`${username}, `, ''));
-    util.setSuccess(200, { data: { likesCount, formattedLikeInfo } });
+    const formattedLikeInfo = Helper.formatLikeInfo(likeInfo, false);
+    util.setSuccess(200, 'Likes successfully retrieved', {
+      data: { likesCount, likeInfo: formattedLikeInfo }
+    });
     return util.send(res);
   }
 }

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -37,9 +37,10 @@ class Helper {
    * @returns {string} token
    */
   static generateToken(payload, expiresInPeriod) {
-    const expiresInTime = expiresInPeriod || (24 * 60 * 60);
-    const token = jwt.sign(payload,
-      process.env.SECRET_KEY, { expiresIn: expiresInTime });
+    const expiresInTime = expiresInPeriod || 24 * 60 * 60;
+    const token = jwt.sign(payload, process.env.SECRET_KEY, {
+      expiresIn: expiresInTime
+    });
     return token;
   }
 
@@ -84,7 +85,7 @@ class Helper {
   static calculateReadTime(body) {
     const readingSpeedInWordsPerMinute = 256; // Average reading speed of an adult
     const wordCount = this.countWords(body);
-    const readTime = Math.ceil((wordCount / readingSpeedInWordsPerMinute));
+    const readTime = Math.ceil(wordCount / readingSpeedInWordsPerMinute);
     const formatedReadTime = `${readTime} min read`;
     return formatedReadTime;
   }
@@ -94,18 +95,19 @@ class Helper {
    *
    * @static
    * @param {*} likeInfo
+   * @param {*} auth
    * @returns {string} formarted comment like information
    * @memberof Helper
    */
-  static formatLikeInfo(likeInfo) {
-    let formattedOutput = 'You';
+  static formatLikeInfo(likeInfo, auth = true) {
+    let formattedOutput = auth ? 'You' : '';
     const usernames = likeInfo.split(', ');
 
     if (usernames.length === 2) {
       formattedOutput += ' like this comment';
       return formattedOutput;
     }
-    for (let i = 1; i < (usernames.length - 1); i += 1) {
+    for (let i = 1; i < usernames.length - 1; i += 1) {
       if (i === 5) break;
       formattedOutput += `, ${usernames[i]} `;
     }
@@ -115,7 +117,8 @@ class Helper {
       return formattedOutput;
     }
 
-    formattedOutput += `and ${(usernames.length - 6)} more people like this comment`;
+    formattedOutput += `and ${usernames.length
+      - 6} more people like this comment`;
     return formattedOutput;
   }
 }

--- a/src/routes/api/comment/comments.route.js
+++ b/src/routes/api/comment/comments.route.js
@@ -9,10 +9,18 @@ router.post('/:slug', [auth, CommentsValidation], Comments.createComment);
 router.get('/:articleSlug', Comments.getAllCommentsOfArticle);
 router.get('/', [auth], Comments.getComments);
 router.delete('/:id', [auth], Comments.deleteComment);
-router.delete('/particularArticle/:id', [auth], Comments.deleteCommentOfAnArticle);
-router.put('/particularArticle/:id', [auth, CommentsValidation], Comments.updateParticularComment);
+router.delete(
+  '/particularArticle/:id',
+  [auth],
+  Comments.deleteCommentOfAnArticle
+);
+router.put(
+  '/particularArticle/:id',
+  [auth, CommentsValidation],
+  Comments.updateParticularComment
+);
 router.put('/:id', [auth, CommentsValidation], Comments.updateComment);
-router.get('/like/:id', [auth, confirmEmailAuth], Comments.getLikesComments);
+router.get('/like/:id', Comments.getLikesComments);
 router.post('/like/:id', [auth, confirmEmailAuth], Comments.likeComment);
 router.put('/like/:id', [auth, confirmEmailAuth], Comments.updateLikeComment);
 


### PR DESCRIPTION

#### What does this PR do?
- Fixes a bug that didn't allow unlogged in user to view comment's likes
- makes both fetch likes responses to look the same for the user who liked the comment and the one who didn't like it yet.
#### Description of Task to be completed?
- Made responses the same
- unlogged in user is able to view likes as well.
#### How should this be manually tested?
- Clone the repo
- run **git checkout bg-retrieve-likes-response-169672715**
- run **npm install**
- add all variables in your .env file.
- run **npm run dev**
- use postman and use GET method with this url **http://localhost:3000/api/v1/comments/like/363**
#### Any background context you want to provide?
- none
#### What are the relevant pivotal tracker stories?
### [#169672715](https://www.pivotaltracker.com/story/show/169672715)
#### Screenshots (if appropriate)
none
#### Questions:
none